### PR TITLE
Replace structopt with clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,8 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap/?rev=93dd22c#93dd22c2f90d8dbc3b059aab01413e8824c1d071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -101,7 +102,8 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap/?rev=93dd22c#93dd22c2f90d8dbc3b059aab01413e8824c1d071"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap/?rev=087fab2#087fab2ab3b643b73e93f9ba7de74f36164d1a45"
+source = "git+https://github.com/clap-rs/clap/?rev=93dd22c#93dd22c2f90d8dbc3b059aab01413e8824c1d071"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -101,7 +101,7 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap/?rev=087fab2#087fab2ab3b643b73e93f9ba7de74f36164d1a45"
+source = "git+https://github.com/clap-rs/clap/?rev=93dd22c#93dd22c2f90d8dbc3b059aab01413e8824c1d071"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,13 +85,29 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "clap"
-version = "2.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap/?rev=087fab2#087fab2ab3b643b73e93f9ba7de74f36164d1a45"
 dependencies = [
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "textwrap",
  "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "git+https://github.com/clap-rs/clap/?rev=087fab2#087fab2ab3b643b73e93f9ba7de74f36164d1a45"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -290,6 +312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,10 +458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 
 [[package]]
+name = "os_str_bytes"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced912e1439b63a8172b943887c33373f226a4a9cfab95d09c0e3c44851d04d4"
+
+[[package]]
 name = "passrs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "data-encoding",
  "git2",
  "gpgme",
@@ -443,7 +481,6 @@ dependencies = [
  "qrcode",
  "regex",
  "ring",
- "structopt",
  "termcolor",
  "termion",
  "thiserror",
@@ -465,9 +502,9 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.2"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -478,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.2"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -633,30 +670,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "structopt"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -812,6 +825,12 @@ name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0.28"
+clap = { git = "https://github.com/clap-rs/clap/", rev = "087fab2", default-features = false, features = ["std", "cargo", "derive"] }
 data-encoding = "2.2.0"
 git2 = { version = "0.13.1", default-features = false }
 gpgme = "0.9.2"
@@ -33,7 +34,6 @@ libc = "0.2.68"
 once_cell = "1.3.1"
 psutil = { version = "3.0.1", default-features = false, features = [ "process" ] }
 ring = { version = "0.16.12", default-features = false }
-structopt = { version = "0.3.13", default-features = false }
 termcolor = "1.1.0"
 termion = "1.5.5"
 thiserror = "1.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0.28"
-clap = { git = "https://github.com/clap-rs/clap/", rev = "93dd22c", default-features = false, features = ["std", "cargo", "derive"] }
+clap = { version = "3.0.0-beta.1", default-features = false, features = ["std", "cargo", "derive"] }
 data-encoding = "2.2.0"
 git2 = { version = "0.13.1", default-features = false }
 gpgme = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 anyhow = "1.0.28"
-clap = { git = "https://github.com/clap-rs/clap/", rev = "087fab2", default-features = false, features = ["std", "cargo", "derive"] }
+clap = { git = "https://github.com/clap-rs/clap/", rev = "93dd22c", default-features = false, features = ["std", "cargo", "derive"] }
 data-encoding = "2.2.0"
 git2 = { version = "0.13.1", default-features = false }
 gpgme = "0.9.2"

--- a/src/util.rs
+++ b/src/util.rs
@@ -168,7 +168,7 @@ where
     if matches.is_empty() {
         Err(PassrsError::NoMatchesFound(target.to_owned()).into())
     } else {
-        matches.sort_by(|a, b| a.to_ascii_lowercase().cmp(&b.to_ascii_lowercase()));
+        matches.sort_by_key(|a| a.to_ascii_lowercase());
 
         Ok(matches)
     }


### PR DESCRIPTION
Once clap v3 releases for real, structopt will be essentially useless (most to all of structopt's features should be folded into clap v3 at that point). Might as well get a leg up and utilize the first beta.